### PR TITLE
Fixed issue #9 in mwielgoszewski/jython-burp-api: Missing ps1 object

### DIFF
--- a/Lib/gds/burp/console/console.py
+++ b/Lib/gds/burp/console/console.py
@@ -22,8 +22,10 @@ from .history import History
 
 
 class Console(object):
-    PS1 = sys.ps1
-    PS2 = sys.ps2
+    # PS1 = sys.ps1
+    # PS2 = sys.ps2
+    PS1 = ">>> "
+    PS2 = "... "
 
     def __init__(self, burp, namespace=None):
         self.burp = burp


### PR DESCRIPTION
For some reason, Burp is not loading the jython package correctly because it does not find the ps1 or ps2 references in the sys module. From the command line, we can see jython's `sys` has both. For now, the easy fix is to replace the references with their hard coded strings.
